### PR TITLE
Add configuration docs; make accessor to API endpoint public

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,28 @@ end
 ```
 
 The docs can be found at [HexDocs](https://hexdocs.pm/nerves_hub_core).
+
+## Environment variables
+
+`NervesHubCore` may be configured using environment variables to simplify
+automation. Environment variables take precedence over configuration. The
+following variables are available:
+
+* `NERVES_HUB_HOST` - NervesHub API endpoint IP address or hostname (defaults to
+  `api.nerves-hub.org`)
+* `NERVES_HUB_PORT` - NervesHub API endpoint port (defaults to 443)
+* `NERVES_LOG_DISABLE_PROGRESS_BAR` - Set to disable the progress bar on file
+  transfers
+* `NERVES_HUB_CA_CERTS` - The path to a directory containing CA certificates for
+  authenticating NervesHub endpoints. Defaults to `nerves-hub.org` certificates.
+
+## Configuration
+
+`NervesHubCore` may also be configured in the `config.exs`. It supports the
+following keys:
+
+* `api_host` - NervesHub API endpoint address (defaults to `api.nerves-hub.org`)
+* `api_port` - NervesHub API endpoint port (defaults to 443)
+* `ca_certs` - The path to a directory containing CA certificates for
+  authenticating NervesHub endpoints. Defaults to `nerves-hub.org` certificates.
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 [![CircleCI](https://circleci.com/gh/nerves-hub/nerves_hub_core.svg?style=svg)](https://circleci.com/gh/nerves-hub/nerves_hub_core)
 [![Hex version](https://img.shields.io/hexpm/v/nerves_hub_core.svg "Hex version")](https://hex.pm/packages/nerves_hub_core)
 
-An HTTP interface for the NervesHub web API.
+This is a library for interacting with a NervesHub website programmatically.
+See [NervesHubCLI](https://github.com/nerves-hub/nerves_hub_cli) for using it
+with `mix`.
+
+Devices do not use this library to connect to a NervesHub server. See
+[NervesHub](https://github.com/nerves-hub/nerves_hub) for the reference client.
 
 ## Installation
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
 config :nerves_hub_core,
-  host: "0.0.0.0",
-  port: 4002
+  api_host: "0.0.0.0",
+  api_port: 4002

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,8 +14,8 @@ end
 working_dir = Path.join(nerves_hub_web_path, "test/fixtures/ssl")
 
 config :nerves_hub_core,
-  host: "0.0.0.0",
-  port: 5002,
+  api_host: "0.0.0.0",
+  api_port: 5002,
   # pass list of paths
   ca_certs: Path.expand("test/fixtures/ssl")
 

--- a/mix.exs
+++ b/mix.exs
@@ -19,6 +19,7 @@ defmodule NervesHubCore.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
+      env: [api_host: "api.nerves-hub.org", api_port: 443],
       extra_applications: [:logger]
     ]
   end


### PR DESCRIPTION
This is mainly intended to support printing out which NervesHub server the CLI connects to. While I made the `endpoint` method public, I refactored the config a little. There are two backwards incompatible changes:

1. `host` and `port` are not `api_host` and `api_port` - I'm not sure if others have found it confusing, but now that we have separate device and management api endpoints, it felt good to be more explicit. I didn't see documentation on this and the one example of using `host` in a config (in `nerves_hub`) was commented out and incorrect. I'm hoping this doesn't break anyone.

2. The previous code consulted the environment if the API host and port weren't specified. This seemed backwards so I made the environment take precedence over the application config. 