### PR TITLE
Try to convert port strings to integers before constructing a URI

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+# Required Vars (ask a dev for this information)
+export DATABASE_URL="postgres://db:db@localhost:2345/db"
+export HOST="0.0.0.0"
+export SECRET_KEY_BASE="3uRRXQ9FUMc3dd7NFTFWQU2xRXcVFXWpPLHZ4fdG/toP9/jJL92Mtjmq8Fd/ijZe"
+
+export SMTP_USERNAME="AKIAJU3ERE5VN66SBK7Q"
+export SMTP_PASSWORD="Aqh9hiKpYXOLRSxKOYyfafQJlKmI6WhCXVYmNkmI4fws"
+export SES_SERVER="email-smtp.us-east-1.amazonaws.com"
+export SES_PORT=587

--- a/lib/nerves_hub_core/api.ex
+++ b/lib/nerves_hub_core/api.ex
@@ -19,7 +19,7 @@ defmodule NervesHubCore.API do
   def endpoint() do
     opts = Application.get_all_env(:nerves_hub_core)
     host = System.get_env("NERVES_HUB_HOST") || opts[:api_host]
-    port = System.get_env("NERVES_HUB_PORT") || opts[:api_port]
+    port = get_env_as_integer("NERVES_HUB_PORT") || opts[:api_port]
 
     %URI{scheme: "https", host: host, port: port, path: "/"} |> URI.to_string()
   end
@@ -136,5 +136,12 @@ defmodule NervesHubCore.API do
     |> Enum.map(&File.read!(Path.join(ca_cert_path, &1)))
     |> Enum.map(&Certificate.from_pem!/1)
     |> Enum.map(&Certificate.to_der/1)
+  end
+
+  defp get_env_as_integer(str) do
+    case System.get_env(str) do
+      nil -> nil
+      value -> String.to_integer(value)
+    end
   end
 end


### PR DESCRIPTION
If you set the environment variable `NERVES_HUB_PORT`, the value comes in as a string but it seems that URI expects an integer.

It will fail with the following error:
```
** (ArgumentError) argument error
    :erlang.integer_to_binary("4002")
    (elixir) lib/uri.ex:653: String.Chars.URI.extract_authority/1
    (elixir) lib/uri.ex:630: String.Chars.URI.to_string/1
    (nerves_hub_cli) lib/mix/nerves_hub/utils.ex:14: Mix.NervesHubCLI.Utils.show_api_endpoint/0
    (nerves_hub_cli) lib/mix/tasks/nerves_hub.key.ex:99: Mix.Tasks.NervesHub.Key.run/1
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```