### PR TITLE
Rename project nerves_hub_user_api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-nerves_hub_core-*.tar
+nerves_hub_user_api-*.tar
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# NervesHubCore
+# NervesHubUserAPI
 
-[![CircleCI](https://circleci.com/gh/nerves-hub/nerves_hub_core.svg?style=svg)](https://circleci.com/gh/nerves-hub/nerves_hub_core)
-[![Hex version](https://img.shields.io/hexpm/v/nerves_hub_core.svg "Hex version")](https://hex.pm/packages/nerves_hub_core)
+[![CircleCI](https://circleci.com/gh/nerves-hub/nerves_hub_user_api.svg?style=svg)](https://circleci.com/gh/nerves-hub/nerves_hub_user_api)
+[![Hex version](https://img.shields.io/hexpm/v/nerves_hub_user_api.svg "Hex version")](https://hex.pm/packages/nerves_hub_user_api)
 
 This is a library for interacting with a NervesHub website programmatically.
 See [NervesHubCLI](https://github.com/nerves-hub/nerves_hub_cli) for using it
@@ -13,21 +13,21 @@ Devices do not use this library to connect to a NervesHub server. See
 ## Installation
 
 The package can be installed
-by adding `nerves_hub_core` to your list of dependencies in `mix.exs`:
+by adding `nerves_hub_user_api` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:nerves_hub_core, "~> 0.1.0"}
+    {:nerves_hub_user_api, "~> 0.1.0"}
   ]
 end
 ```
 
-The docs can be found at [HexDocs](https://hexdocs.pm/nerves_hub_core).
+The docs can be found at [HexDocs](https://hexdocs.pm/nerves_hub_user_api).
 
 ## Environment variables
 
-`NervesHubCore` may be configured using environment variables to simplify
+`NervesHubUserAPI` may be configured using environment variables to simplify
 automation. Environment variables take precedence over configuration. The
 following variables are available:
 
@@ -41,11 +41,11 @@ following variables are available:
 
 ## Configuration
 
-`NervesHubCore` may also be configured in the `config.exs`. It supports the
+`NervesHubUserAPI` may also be configured in the `config.exs`. It supports the
 following keys:
 
-* `api_host` - NervesHub API endpoint address (defaults to `api.nerves-hub.org`)
-* `api_port` - NervesHub API endpoint port (defaults to 443)
+* `host` - NervesHub API endpoint address (defaults to `api.nerves-hub.org`)
+* `port` - NervesHub API endpoint port (defaults to 443)
 * `ca_certs` - The path to a directory containing CA certificates for
   authenticating NervesHub endpoints. Defaults to `nerves-hub.org` certificates.
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
-config :nerves_hub_core,
-  api_host: "0.0.0.0",
-  api_port: 4002
+config :nerves_hub_user_api,
+  host: "0.0.0.0",
+  port: 4002

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,9 +13,9 @@ end
 
 working_dir = Path.join(nerves_hub_web_path, "test/fixtures/ssl")
 
-config :nerves_hub_core,
-  api_host: "0.0.0.0",
-  api_port: 5002,
+config :nerves_hub_user_api,
+  host: "0.0.0.0",
+  port: 5002,
   # pass list of paths
   ca_certs: Path.expand("test/fixtures/ssl")
 

--- a/lib/nerves_hub_core.ex
+++ b/lib/nerves_hub_core.ex
@@ -1,2 +1,0 @@
-defmodule NervesHubCore do
-end

--- a/lib/nerves_hub_user_api.ex
+++ b/lib/nerves_hub_user_api.ex
@@ -1,0 +1,2 @@
+defmodule NervesHubUserAPI do
+end

--- a/lib/nerves_hub_user_api/api.ex
+++ b/lib/nerves_hub_user_api/api.ex
@@ -1,11 +1,11 @@
-defmodule NervesHubCore.API do
+defmodule NervesHubUserAPI.API do
   @moduledoc false
 
   @file_chunk 4096
   @progress_steps 50
 
   use Tesla
-  adapter(Tesla.Adapter.Hackney, pool: :nerves_hub_core)
+  adapter(Tesla.Adapter.Hackney, pool: :nerves_hub_user_api)
   if Mix.env() == :dev, do: plug(Tesla.Middleware.Logger)
   plug(Tesla.Middleware.FollowRedirects, max_redirects: 5)
   plug(Tesla.Middleware.JSON)
@@ -17,9 +17,9 @@ defmodule NervesHubCore.API do
   """
   @spec endpoint() :: String.t()
   def endpoint() do
-    opts = Application.get_all_env(:nerves_hub_core)
-    host = System.get_env("NERVES_HUB_HOST") || opts[:api_host]
-    port = get_env_as_integer("NERVES_HUB_PORT") || opts[:api_port]
+    opts = Application.get_all_env(:nerves_hub_user_api)
+    host = System.get_env("NERVES_HUB_HOST") || opts[:host]
+    port = get_env_as_integer("NERVES_HUB_PORT") || opts[:port]
 
     %URI{scheme: "https", host: host, port: port, path: "/"} |> URI.to_string()
   end
@@ -126,8 +126,9 @@ defmodule NervesHubCore.API do
 
   defp ca_certs() do
     ca_cert_path =
-      Application.get_env(:nerves_hub_core, :ca_certs) || System.get_env("NERVES_HUB_CA_CERTS") ||
-        :code.priv_dir(:nerves_hub_core)
+      Application.get_env(:nerves_hub_user_api, :ca_certs) ||
+        System.get_env("NERVES_HUB_CA_CERTS") ||
+        :code.priv_dir(:nerves_hub_user_api)
         |> to_string()
         |> Path.join("ca_certs")
 

--- a/lib/nerves_hub_user_api/auth.ex
+++ b/lib/nerves_hub_user_api/auth.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubCore.Auth do
+defmodule NervesHubUserAPI.Auth do
   defstruct cert: nil,
             key: nil
 
@@ -7,7 +7,7 @@ defmodule NervesHubCore.Auth do
           key: X509.PrivateKey.t()
         }
 
-  @spec new(keyword() | map()) :: NervesHubCore.Auth.t()
+  @spec new(keyword() | map()) :: NervesHubUserAPI.Auth.t()
   def new(opts) do
     %__MODULE__{
       cert: opts[:cert],

--- a/lib/nerves_hub_user_api/ca_certificate.ex
+++ b/lib/nerves_hub_user_api/ca_certificate.ex
@@ -1,11 +1,11 @@
-defmodule NervesHubCore.CACertificate do
+defmodule NervesHubUserAPI.CACertificate do
   @moduledoc """
   CA certificates
 
   Path: /orgs/:org_name/ca_certificates
   """
 
-  alias NervesHubCore.{Auth, API, Org}
+  alias NervesHubUserAPI.{Auth, API, Org}
 
   @path "ca_certificates"
 
@@ -15,7 +15,7 @@ defmodule NervesHubCore.CACertificate do
   Verb: GET
   Path: /orgs/:org_name/ca_certificates
   """
-  @spec list(atom() | binary(), NervesHubCore.Auth.t()) :: {:error, any()} | {:ok, any()}
+  @spec list(atom() | binary(), NervesHubUserAPI.Auth.t()) :: {:error, any()} | {:ok, any()}
   def list(org_name, %Auth{} = auth) do
     API.request(:get, path(org_name), "", auth)
   end
@@ -27,7 +27,7 @@ defmodule NervesHubCore.CACertificate do
   Verb: POST
   Path: /orgs/:org_name/ca_certificates
   """
-  @spec create(atom() | binary(), binary(), NervesHubCore.Auth.t()) ::
+  @spec create(atom() | binary(), binary(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def create(org_name, cert_pem, %Auth{} = auth) do
     params = %{cert: Base.encode64(cert_pem)}
@@ -40,7 +40,7 @@ defmodule NervesHubCore.CACertificate do
   Verb: DELETE
   Path: /orgs/:org_name/ca_certificates/:serial
   """
-  @spec delete(atom() | binary(), binary(), NervesHubCore.Auth.t()) ::
+  @spec delete(atom() | binary(), binary(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def delete(org_name, serial, %Auth{} = auth) do
     API.request(:delete, path(org_name, serial), "", auth)

--- a/lib/nerves_hub_user_api/deployment.ex
+++ b/lib/nerves_hub_user_api/deployment.ex
@@ -1,10 +1,10 @@
-defmodule NervesHubCore.Deployment do
+defmodule NervesHubUserAPI.Deployment do
   @moduledoc """
   Manage NervesHub deployments
 
   Path: /orgs/:org_name/products/:product_name/deployments
   """
-  alias NervesHubCore.{Auth, API, Product}
+  alias NervesHubUserAPI.{Auth, API, Product}
 
   @path "deployments"
 
@@ -14,7 +14,7 @@ defmodule NervesHubCore.Deployment do
   Verb: GET
   Path: /orgs/:org_name/products/:product_name/deployments
   """
-  @spec list(atom() | binary(), atom() | binary(), NervesHubCore.Auth.t()) ::
+  @spec list(atom() | binary(), atom() | binary(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def list(org_name, product_name, %Auth{} = auth) do
     API.request(:get, path(org_name, product_name), "", auth)
@@ -33,7 +33,7 @@ defmodule NervesHubCore.Deployment do
           atom() | binary(),
           atom() | binary(),
           [atom() | binary()],
-          NervesHubCore.Auth.t()
+          NervesHubUserAPI.Auth.t()
         ) :: {:error, any()} | {:ok, any()}
   def create(org_name, product_name, name, firmware_uuid, version, tags, %Auth{} = auth) do
     params = %{
@@ -52,7 +52,7 @@ defmodule NervesHubCore.Deployment do
   Verb: PUT
   Path: /orgs/:org_name/products/:product_name/deployments/:depolyment_name
   """
-  @spec update(atom() | binary(), atom() | binary(), binary(), map(), NervesHubCore.Auth.t()) ::
+  @spec update(atom() | binary(), atom() | binary(), binary(), map(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def update(org_name, product_name, deployment_name, params, %Auth{} = auth) do
     params = %{deployment: params}

--- a/lib/nerves_hub_user_api/device.ex
+++ b/lib/nerves_hub_user_api/device.ex
@@ -1,11 +1,11 @@
-defmodule NervesHubCore.Device do
+defmodule NervesHubUserAPI.Device do
   @moduledoc """
   Manage NervesHub devices
 
   Path: /orgs/:org_name/devices
   """
 
-  alias NervesHubCore.{Auth, API, Org}
+  alias NervesHubUserAPI.{Auth, API, Org}
 
   @path "devices"
 
@@ -15,7 +15,7 @@ defmodule NervesHubCore.Device do
   Verb: GET
   Path: /orgs/:org_name/devices
   """
-  @spec list(atom() | binary(), NervesHubCore.Auth.t()) :: {:error, any()} | {:ok, any()}
+  @spec list(atom() | binary(), NervesHubUserAPI.Auth.t()) :: {:error, any()} | {:ok, any()}
   def list(org_name, %Auth{} = auth) do
     API.request(:get, path(org_name), "", auth)
   end
@@ -26,7 +26,7 @@ defmodule NervesHubCore.Device do
   Verb: POST
   Path: /orgs/:org_name/devices
   """
-  @spec create(atom() | binary(), binary(), binary(), [binary()], NervesHubCore.Auth.t()) ::
+  @spec create(atom() | binary(), binary(), binary(), [binary()], NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def create(org_name, identifier, description, tags, %Auth{} = auth) do
     params = %{identifier: identifier, description: description, tags: tags}
@@ -39,7 +39,7 @@ defmodule NervesHubCore.Device do
   Verb: PUT
   Path: /orgs/:org_name/devices/:device_identifier
   """
-  @spec update(atom() | binary(), binary(), map(), NervesHubCore.Auth.t()) ::
+  @spec update(atom() | binary(), binary(), map(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def update(org_name, device_identifier, params, %Auth{} = auth) do
     params = Map.merge(params, %{identifier: device_identifier})
@@ -52,7 +52,7 @@ defmodule NervesHubCore.Device do
   Verb: POST
   Path: /orgs/:org_name/devices/auth
   """
-  @spec auth(atom() | binary(), binary(), NervesHubCore.Auth.t()) ::
+  @spec auth(atom() | binary(), binary(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def auth(org_name, cert_pem, %Auth{} = auth) do
     params = %{certificate: Base.encode64(cert_pem)}
@@ -66,7 +66,7 @@ defmodule NervesHubCore.Device do
   Verb: GET
   Path: /orgs/:org_name/devices/:device_identifier/certificates
   """
-  @spec cert_list(atom() | binary(), binary(), NervesHubCore.Auth.t()) ::
+  @spec cert_list(atom() | binary(), binary(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def cert_list(org_name, device_identifier, %Auth{} = auth) do
     API.request(:get, cert_path(org_name, device_identifier), "", auth)
@@ -78,7 +78,7 @@ defmodule NervesHubCore.Device do
   Verb: POST
   Path: /orgs/:org_name/devices/:device_identifier/certificates/sign
   """
-  @spec cert_sign(atom() | binary(), binary(), binary(), NervesHubCore.Auth.t()) ::
+  @spec cert_sign(atom() | binary(), binary(), binary(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def cert_sign(org_name, device_identifier, csr, %Auth{} = auth) do
     params = %{identifier: device_identifier, csr: csr}

--- a/lib/nerves_hub_user_api/firmware.ex
+++ b/lib/nerves_hub_user_api/firmware.ex
@@ -1,11 +1,11 @@
-defmodule NervesHubCore.Firmware do
+defmodule NervesHubUserAPI.Firmware do
   @moduledoc """
   Manage Firmware on NervesHub
 
   Path: /orgs/:org_name/products/:product_name/firmwares
   """
 
-  alias NervesHubCore.{Auth, API, Product}
+  alias NervesHubUserAPI.{Auth, API, Product}
 
   @path "firmwares"
 
@@ -15,7 +15,7 @@ defmodule NervesHubCore.Firmware do
   Verb: GET
   Path: /orgs/:org_name/products/:product_name/firmwares
   """
-  @spec list(atom() | binary(), atom() | binary(), NervesHubCore.Auth.t()) ::
+  @spec list(atom() | binary(), atom() | binary(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def list(org_name, product_name, %Auth{} = auth) do
     API.request(:get, path(org_name, product_name), "", auth)
@@ -32,7 +32,7 @@ defmodule NervesHubCore.Firmware do
           atom() | binary(),
           atom() | binary(),
           non_neg_integer() | nil,
-          NervesHubCore.Auth.t()
+          NervesHubUserAPI.Auth.t()
         ) :: {:error, any()} | {:ok, any()}
   def create(org_name, product_name, tar, ttl \\ nil, %Auth{} = auth) do
     params = if ttl != nil, do: %{ttl: ttl}, else: %{}
@@ -49,7 +49,7 @@ defmodule NervesHubCore.Firmware do
           atom() | binary(),
           atom() | binary(),
           binary(),
-          NervesHubCore.Auth.t()
+          NervesHubUserAPI.Auth.t()
         ) :: {:error, any()} | {:ok, any()}
   def delete(org_name, product_name, uuid, %Auth{} = auth) do
     path = Path.join(path(org_name, product_name), uuid)

--- a/lib/nerves_hub_user_api/key.ex
+++ b/lib/nerves_hub_user_api/key.ex
@@ -1,11 +1,11 @@
-defmodule NervesHubCore.Key do
+defmodule NervesHubUserAPI.Key do
   @moduledoc """
   Manages firmware signing keys
 
   Path: /orgs/:org_name/keys
   """
 
-  alias NervesHubCore.{Auth, API, Org}
+  alias NervesHubUserAPI.{Auth, API, Org}
 
   @path "keys"
 
@@ -15,7 +15,7 @@ defmodule NervesHubCore.Key do
   Verb: GET
   Path: /orgs/:org_name/keys
   """
-  @spec list(atom() | binary(), NervesHubCore.Auth.t()) :: {:error, any()} | {:ok, any()}
+  @spec list(atom() | binary(), NervesHubUserAPI.Auth.t()) :: {:error, any()} | {:ok, any()}
   def list(org_name, %Auth{} = auth) do
     API.request(:get, path(org_name), "", auth)
   end
@@ -26,7 +26,7 @@ defmodule NervesHubCore.Key do
   Verb: POST
   Path: /orgs/:org_name/keys
   """
-  @spec create(atom() | binary(), binary(), binary(), NervesHubCore.Auth.t()) ::
+  @spec create(atom() | binary(), binary(), binary(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def create(org_name, key_name, key, %Auth{} = auth) do
     params = %{name: key_name, key: key}
@@ -39,7 +39,7 @@ defmodule NervesHubCore.Key do
   Verb: DELETE
   Path: /orgs/:org_name/keys/:key_name
   """
-  @spec delete(atom() | binary(), binary(), NervesHubCore.Auth.t()) ::
+  @spec delete(atom() | binary(), binary(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def delete(org_name, key_name, %Auth{} = auth) do
     API.request(:delete, path(org_name, key_name), "", auth)

--- a/lib/nerves_hub_user_api/org.ex
+++ b/lib/nerves_hub_user_api/org.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubCore.Org do
+defmodule NervesHubUserAPI.Org do
   @moduledoc false
 
   @path "orgs"

--- a/lib/nerves_hub_user_api/product.ex
+++ b/lib/nerves_hub_user_api/product.ex
@@ -1,11 +1,11 @@
-defmodule NervesHubCore.Product do
+defmodule NervesHubUserAPI.Product do
   @moduledoc """
   Manage products on NervesHub
 
   Path: /orgs/:org_name/products
   """
 
-  alias NervesHubCore.{Auth, API, Org}
+  alias NervesHubUserAPI.{Auth, API, Org}
 
   @path "products"
 
@@ -15,7 +15,7 @@ defmodule NervesHubCore.Product do
   Verb: GET
   Path: /orgs/:org_name/products
   """
-  @spec list(atom() | binary(), NervesHubCore.Auth.t()) :: {:error, any()} | {:ok, any()}
+  @spec list(atom() | binary(), NervesHubUserAPI.Auth.t()) :: {:error, any()} | {:ok, any()}
   def list(org_name, %Auth{} = auth) do
     API.request(:get, path(org_name), "", auth)
   end
@@ -26,7 +26,8 @@ defmodule NervesHubCore.Product do
   Verb: POST
   Path: /orgs/:org_name/products
   """
-  @spec create(atom() | binary(), any(), NervesHubCore.Auth.t()) :: {:error, any()} | {:ok, any()}
+  @spec create(atom() | binary(), any(), NervesHubUserAPI.Auth.t()) ::
+          {:error, any()} | {:ok, any()}
   def create(org_name, product_name, %Auth{} = auth) do
     params = %{name: product_name}
     API.request(:post, path(org_name), params, auth)
@@ -38,7 +39,7 @@ defmodule NervesHubCore.Product do
   Verb: DELETE
   Path: /orgs/:org_name/products/:product_name
   """
-  @spec delete(atom() | binary(), atom() | binary(), NervesHubCore.Auth.t()) ::
+  @spec delete(atom() | binary(), atom() | binary(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def delete(org_name, product_name, %Auth{} = auth) do
     API.request(:delete, path(org_name, product_name), "", auth)
@@ -50,7 +51,7 @@ defmodule NervesHubCore.Product do
   Verb: PUT
   Path: /orgs/:org_name/products/:product_name
   """
-  @spec update(atom() | binary(), atom() | binary(), map(), NervesHubCore.Auth.t()) ::
+  @spec update(atom() | binary(), atom() | binary(), map(), NervesHubUserAPI.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def update(org_name, product_name, params, %Auth{} = auth) do
     params = %{product: params}

--- a/lib/nerves_hub_user_api/user.ex
+++ b/lib/nerves_hub_user_api/user.ex
@@ -1,11 +1,11 @@
-defmodule NervesHubCore.User do
+defmodule NervesHubUserAPI.User do
   @moduledoc """
   Manage NervesHub users
 
   Path: /users
   """
 
-  alias NervesHubCore.{Auth, API}
+  alias NervesHubUserAPI.{Auth, API}
 
   # Certificate protected
   @doc """
@@ -14,7 +14,7 @@ defmodule NervesHubCore.User do
   Verb: GET
   Path: /users/me
   """
-  @spec me(NervesHubCore.Auth.t()) :: {:error, any()} | {:ok, any()}
+  @spec me(NervesHubUserAPI.Auth.t()) :: {:error, any()} | {:ok, any()}
   def me(%Auth{} = auth) do
     API.request(:get, "users/me", "", auth)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,9 +1,9 @@
-defmodule NervesHubCore.MixProject do
+defmodule NervesHubUserAPI.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :nerves_hub_core,
+      app: :nerves_hub_user_api,
       version: "0.3.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
@@ -19,19 +19,19 @@ defmodule NervesHubCore.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      env: [api_host: "api.nerves-hub.org", api_port: 443],
+      env: [host: "api.nerves-hub.org", port: 443],
       extra_applications: [:logger]
     ]
   end
 
   defp description do
-    "NervesHub API client"
+    "NervesHub Management API client"
   end
 
   defp package do
     [
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/nerves-hub/nerves_hub_core"}
+      links: %{"GitHub" => "https://github.com/nerves-hub/nerves_hub_user_api"}
     ]
   end
 

--- a/test/nerves_hub_user_api/ca_certificate_test.exs
+++ b/test/nerves_hub_user_api/ca_certificate_test.exs
@@ -1,8 +1,8 @@
 defmodule NervesHubCoreTest.CACertificateTest do
   use NervesHubCoreTest.Case
-  doctest NervesHubCore.CACertificate
+  doctest NervesHubUserAPI.CACertificate
 
-  alias NervesHubCore.CACertificate
+  alias NervesHubUserAPI.CACertificate
 
   describe "create" do
     setup [:create_user]

--- a/test/nerves_hub_user_api/deployment_test.exs
+++ b/test/nerves_hub_user_api/deployment_test.exs
@@ -1,8 +1,8 @@
 defmodule NervesHubCoreTest.DeploymentTest do
   use NervesHubCoreTest.Case
-  doctest NervesHubCore.Deployment
+  doctest NervesHubUserAPI.Deployment
 
-  alias NervesHubCore.Deployment
+  alias NervesHubUserAPI.Deployment
 
   describe "create" do
     setup [:create_user, :create_key, :create_product, :create_firmware]

--- a/test/nerves_hub_user_api/device_test.exs
+++ b/test/nerves_hub_user_api/device_test.exs
@@ -1,8 +1,8 @@
 defmodule NervesHubCoreTest.DeviceTest do
   use NervesHubCoreTest.Case
-  doctest NervesHubCore.Device
+  doctest NervesHubUserAPI.Device
 
-  alias NervesHubCore.Device
+  alias NervesHubUserAPI.Device
 
   describe "create" do
     setup [:create_user]

--- a/test/nerves_hub_user_api/firmware_test.exs
+++ b/test/nerves_hub_user_api/firmware_test.exs
@@ -1,8 +1,8 @@
 defmodule NervesHubCoreTest.FirmwareTest do
   use NervesHubCoreTest.Case
-  doctest NervesHubCore.Firmware
+  doctest NervesHubUserAPI.Firmware
 
-  alias NervesHubCore.Firmware
+  alias NervesHubUserAPI.Firmware
 
   describe "create" do
     setup [:create_user, :create_key, :create_product]

--- a/test/nerves_hub_user_api/key_test.exs
+++ b/test/nerves_hub_user_api/key_test.exs
@@ -1,8 +1,8 @@
 defmodule NervesHubCoreTest.KeyTest do
   use NervesHubCoreTest.Case
-  doctest NervesHubCore.Key
+  doctest NervesHubUserAPI.Key
 
-  alias NervesHubCore.Key
+  alias NervesHubUserAPI.Key
 
   describe "create" do
     setup [:create_user]

--- a/test/nerves_hub_user_api/product_test.exs
+++ b/test/nerves_hub_user_api/product_test.exs
@@ -1,8 +1,8 @@
 defmodule NervesHubCoreTest.ProductTest do
   use NervesHubCoreTest.Case
-  doctest NervesHubCore.Product
+  doctest NervesHubUserAPI.Product
 
-  alias NervesHubCore.Product
+  alias NervesHubUserAPI.Product
 
   describe "create" do
     setup [:create_user]

--- a/test/nerves_hub_user_api/user_test.exs
+++ b/test/nerves_hub_user_api/user_test.exs
@@ -1,8 +1,8 @@
 defmodule NervesHubCoreTest.UserTest do
   use NervesHubCoreTest.Case
-  doctest NervesHubCore.User
+  doctest NervesHubUserAPI.User
 
-  alias NervesHubCore.User
+  alias NervesHubUserAPI.User
 
   describe "register" do
     test "valid" do

--- a/test/nerves_hub_user_api_test.exs
+++ b/test/nerves_hub_user_api_test.exs
@@ -1,4 +1,4 @@
 defmodule NervesHubCoreTest do
   use ExUnit.Case
-  doctest NervesHubCore
+  doctest NervesHubUserAPI
 end

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -31,11 +31,11 @@ defmodule NervesHubCoreTest.Case do
     csr64 = Base.encode64(csr_pem)
 
     {:ok, %{"data" => %{"cert" => cert}}} =
-      NervesHubCore.User.sign(Fixtures.user_email(), Fixtures.user_password(), csr64, "test")
+      NervesHubUserAPI.User.sign(Fixtures.user_email(), Fixtures.user_password(), csr64, "test")
 
     recycle_pool()
 
-    auth = NervesHubCore.Auth.new(key: key, cert: X509.Certificate.from_pem!(cert))
+    auth = NervesHubUserAPI.Auth.new(key: key, cert: X509.Certificate.from_pem!(cert))
     {:ok, Map.merge(context, %{user: user, auth: auth})}
   end
 
@@ -61,7 +61,7 @@ defmodule NervesHubCoreTest.Case do
     csr64 = Base.encode64(csr_pem)
 
     {:ok, %{"data" => resp}} =
-      NervesHubCore.Device.cert_sign(context.user["username"], device_identifier, csr64, auth)
+      NervesHubUserAPI.Device.cert_sign(context.user["username"], device_identifier, csr64, auth)
 
     {:ok, Map.merge(context, %{device: device, device_cert: resp["cert"]})}
   end
@@ -76,7 +76,7 @@ defmodule NervesHubCoreTest.Case do
   end
 
   defp recycle_pool do
-    pool_name = :nerves_hub_core
+    pool_name = :nerves_hub_user_api
     :hackney_pool.stop_pool(pool_name)
     opts = [timeout: 5_000, max_connections: 5]
     :ok = :hackney_pool.start_pool(pool_name, opts)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -19,7 +19,7 @@ defmodule NervesHubCoreTest.Fixtures do
   @deployment_tags ["test"]
   @deployment_version "1.0.0"
 
-  alias NervesHubCore.{User, Key, Product, Firmware, Device, Deployment, CACertificate}
+  alias NervesHubUserAPI.{User, Key, Product, Firmware, Device, Deployment, CACertificate}
 
   def user_name, do: @user_name
   def user_email, do: @email

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,7 @@
 ExUnit.start()
 
 opts = [timeout: 5_000, max_connections: 5]
-:ok = :hackney_pool.start_pool(:nerves_hub_core, opts)
+:ok = :hackney_pool.start_pool(:nerves_hub_user_api, opts)
 
 System.put_env("NERVES_LOG_DISABLE_PROGRESS_BAR", "true")
 


### PR DESCRIPTION
This project was originally named `nerves_hub_core` to following along side `hex_core` as an attempt to help users understand its functionality by comparison. Due to differences between NervesHub's structure and Hex, `nerves_hub_core` is a bit ambiguous in terms of what it does. The reality is that this project is a client for the NervesHub User API. Therefore, it made more sense to change the name. 